### PR TITLE
fix "can't resolve 'fs' in '...'" storybook bug

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,5 +6,6 @@ module.exports = {
   "addons": [
     "@storybook/addon-links",
     "@storybook/addon-essentials"
-  ]
+  ],
+  webpackFinal: async (config) => ({ node: { fs: "empty" }, ...config })
 }


### PR DESCRIPTION
When launching storybook, it crashes (on my machine) due to an undebate module not being able to resolve 'fs'.
This removes that dependency, which stops it crashing.